### PR TITLE
fix: keep map height from collapsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,35 +1,39 @@
-
 <!DOCTYPE html>
 <html>
+
 <head>
-    <title>Missouri Organization Members Map</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
-    <style>
-        #map { height: 100vh; }
-    </style>
+    <title>Missouri Organization Members Map</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+    <style>
+        #map {
+            height: 100vh;
+        }
+    </style>
 </head>
+
 <body>
-    <div id="map"></div>
-    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
-    <script src="data.js"></script>
-    <script>
-        var map = L.map('map').setView([38.573936, -92.603760], 7); // Centered on Missouri
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+    <script src="data.js"></script>
+    <script>
+        var map = L.map('map').setView([38.573936, -92.603760], 7); // Centered on Missouri
 
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        }).addTo(map);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
 
-        members.forEach(function(member) {
-            var marker = L.marker([member.lat, member.lon]).addTo(map);
-            marker.bindPopup(
-                "<b>" + member.name + "</b><br>" +
-                "Position: " + member.position + "<br>" +
-                "Email: <a href='mailto:" + member.email + "'>" + member.email + "</a><br>" +
-                "Expertise: " + member.expertise
-            );
-        });
-    </script>
+        members.forEach(function (member) {
+            var marker = L.marker([member.lat, member.lon]).addTo(map);
+            marker.bindPopup(
+                "<b>" + member.name + "</b><br>" +
+                "Position: " + member.position + "<br>" +
+                "Email: <a href='mailto:" + member.email + "'>" + member.email + "</a><br>" +
+                "Expertise: " + member.expertise
+            );
+        });
+    </script>
 </body>
+
 </html>


### PR DESCRIPTION
Weird whitespace characters were in the code—maybe from copy and paste?—that showed up in the browser as multiple `&nbps;` entities. This kept the `#map { height: 100vh; }` css from being recognized, leaving the map container with a height of 0